### PR TITLE
✨ FEAT : 점주리뷰관리 페이지 생성 및 기타사항 수정

### DIFF
--- a/src/main/java/com/eathub/api/OwnerReviewApi.java
+++ b/src/main/java/com/eathub/api/OwnerReviewApi.java
@@ -1,0 +1,29 @@
+package com.eathub.api;
+
+import com.eathub.dto.ReviewDTO;
+import com.eathub.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/ownerReviews")
+public class OwnerReviewApi {
+    private final ReviewService reviewService;
+    @GetMapping("")
+    public ResponseEntity<?> getReviews(@RequestParam("page") int page, @RequestParam("member_seq") Long member_seq) {
+        List<ReviewDTO> reviewDTOs = reviewService.selectOwnerReviewAndImages(member_seq, page);
+        if (reviewDTOs != null) {
+            return ResponseEntity.ok(reviewDTOs);
+        }
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/eathub/controller/MyReviewController.java
+++ b/src/main/java/com/eathub/controller/MyReviewController.java
@@ -5,6 +5,7 @@ import com.eathub.dto.ReservationDTO;
 import com.eathub.dto.RestaurantDetailDTO;
 import com.eathub.dto.ReviewDTO;
 import com.eathub.dto.ReviewStatsDTO;
+import com.eathub.entity.ENUM.MEMBER_TYPE;
 import com.eathub.entity.RestaurantInfo;
 import com.eathub.service.MemberService;
 import com.eathub.service.RestaurantService;
@@ -34,9 +35,17 @@ public class MyReviewController {
     @GetMapping("")
     public String review(Model model, HttpSession session){
         Long member_seq = (Long) session.getAttribute(SessionConf.LOGIN_MEMBER_SEQ);
+        MEMBER_TYPE mem_type = (MEMBER_TYPE) session.getAttribute(SessionConf.LOGIN_MEMBER_TYPE);
 
         model.addAttribute("member_seq", member_seq);
+
+        if(mem_type.equals(MEMBER_TYPE.OWNER)){
+            return "/members/ownerReview";
+
+        }
+
         return "/members/myReview";
+
     }
 
 

--- a/src/main/java/com/eathub/mapper/ReviewMapper.java
+++ b/src/main/java/com/eathub/mapper/ReviewMapper.java
@@ -46,6 +46,13 @@ public interface ReviewMapper {
 
     List<ReviewDTO> selectMyReview(Long memberSeq);
 
+    //고객 리뷰관리 페이지
     List<ReviewDTO> selectMyReviewListPage(@Param("member_seq") Long member_seq, @Param("page") int page);
+
+    //점주 리뷰관리 페이지
+    List<ReviewDTO> selectOwnerReviewListPage(@Param("member_seq") Long member_seq, @Param("page") int page);
+
+
+
     //    DELETE
 }

--- a/src/main/java/com/eathub/service/ReviewService.java
+++ b/src/main/java/com/eathub/service/ReviewService.java
@@ -116,12 +116,25 @@ public class ReviewService {
         return reviewDTO;
     }
 
+    //고객 리뷰관리 페이지
     public List<ReviewDTO> selectMyReviewAndImages(Long member_seq, int page) {
         List<ReviewDTO> reviewDTO = reviewMapper.selectMyReviewListPage(member_seq, (page-1)*2);
         for (ReviewDTO dto : reviewDTO) {
             List<String> reviewImages = reviewMapper.selectReviewImages(dto.getRes_seq());
             dto.setPictureUrls(reviewImages);
         }
+        return reviewDTO;
+    }
+
+    //점주 리뷰관리 페이지
+    public List<ReviewDTO> selectOwnerReviewAndImages(Long member_seq, int page) {
+        List<ReviewDTO> reviewDTO = reviewMapper.selectOwnerReviewListPage(member_seq, (page-1)*2);
+        for (ReviewDTO dto : reviewDTO) {
+            List<String> reviewImages = reviewMapper.selectReviewImages(dto.getRes_seq());
+            dto.setPictureUrls(reviewImages);
+        }
+
+        System.out.println("page = " + page);
         return reviewDTO;
     }
     //    UPDATE

--- a/src/main/resources/mapper/RestaurantMapper.xml
+++ b/src/main/resources/mapper/RestaurantMapper.xml
@@ -161,6 +161,7 @@
         SELECT restaurant_seq,member_seq,category_seq,restaurant_name,tag,location,description,openHour,closeHour,rating,review_total,zzim_total
         FROM restaurant_info
         WHERE  category_seq= #{category_seq} and status = 'ACCESS'
+        ORDER BY rating DESC
         LIMIT 20
     </select>
 
@@ -195,14 +196,15 @@
         SELECT restaurant_seq,member_seq,category_seq,restaurant_name,tag,lower(location),description,openHour,closeHour,rating,review_total,zzim_total,address1
         FROM restaurant_info
         WHERE
-        <foreach item="item" index="index" collection="list" open="(" separator="OR" close=")">
-            address1 LIKE #{item}
-        </foreach>
-        and
-        <foreach item="item" index="index" collection="list" open="(" separator="OR" close=")">
-            tag LIKE #{item}
-        </foreach>
-        and status = 'ACCESS'
+            <foreach item="item" index="index" collection="list" open="(" separator="OR" close=")">
+                address1 LIKE #{item}
+            </foreach>
+            and
+            <foreach item="item" index="index" collection="list" open="(" separator="OR" close=")">
+                tag LIKE #{item}
+            </foreach>
+            and status = 'ACCESS'
+        ORDER BY rating DESC
     </select>
 
     <!-- 오늘의 예약 -->

--- a/src/main/resources/mapper/ReviewMapper.xml
+++ b/src/main/resources/mapper/ReviewMapper.xml
@@ -87,14 +87,29 @@
 
 
 
-<!--myReview -->
+    <!--myReview -->
     <select id="selectMyReviewListPage" resultType="com.eathub.dto.ReviewDTO">
         SELECT res_seq, review.rating, content, restaurant_seq, reservation.member_seq, review.createdAt, restaurant_name
         FROM review
                  LEFT JOIN reservation USING (res_seq)
                  LEFT JOIN restaurant_info USING (restaurant_seq)
         WHERE reservation.member_seq = #{member_seq}
-        ORDER BY review.rating DESC, res_seq DESC
+        ORDER BY review.createdAt DESC, rating DESC
+        LIMIT #{page},2;
+    </select>
+
+    <!-- ownerReview -->
+    <select id="selectOwnerReviewListPage" resultType="com.eathub.dto.ReviewDTO">
+        SELECT res_seq, review.rating, content, restaurant_seq, reservation.member_seq, review.createdAt, restaurant_name
+        FROM review
+                 LEFT JOIN reservation USING (res_seq)
+                 LEFT JOIN restaurant_info USING (restaurant_seq)
+        WHERE restaurant_seq IN (
+            SELECT restaurant_seq
+            FROM restaurant_info
+            WHERE member_seq = #{member_seq}
+        )
+        ORDER BY review.createdAt DESC, rating DESC
         LIMIT #{page},2;
     </select>
 </mapper>

--- a/src/main/webapp/WEB-INF/resources/js/ownerReview.js
+++ b/src/main/webapp/WEB-INF/resources/js/ownerReview.js
@@ -73,7 +73,7 @@ function fetchAndAppendReviews() {
     isFetching = true;
     document.getElementById('loading').style.display = 'block';
 
-    fetch(`/api/myReviews?page=${pageNumber}&member_seq=${member_seq}`)
+    fetch(`/api/ownerReviews?page=${pageNumber}&member_seq=${member_seq}`)
         .then(response => response.json())
         .then(data => {
             console.log('Loaded reviews:', data);

--- a/src/main/webapp/WEB-INF/views/members/ownerReview.html
+++ b/src/main/webapp/WEB-INF/views/members/ownerReview.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover" name="viewport">
+    <meta charset="UTF-8">
+    <link rel="stylesheet" href="../../resources/css/review.css" th:href="@{/css/review.css}"/>
+    <link rel="stylesheet"  href="../resources/css/footer.css" th:href="@{/css/footer.css}">
+    <script defer src="../../resources/js/review.js" th:src="@{/js/ownerReview.js}"></script>
+    <title>리뷰관리</title>
+</head>
+<body class="disable-user-select">
+<!-- Ajax요청을 보낼때 레스토랑 seq를 확인해서 가져감-->
+<input type="hidden" id="member_seq" th:value="${member_seq}">
+
+<div class="wrapper" id="wrapperDiv">
+    <header id="header" class="opaque">
+        <div class="container">
+            <div class="header-left">
+                <h1 class="page-title" style="padding-right: 4px;">리뷰관리</h1>
+            </div>
+        </div>
+    </header>
+    <main id="main">
+
+        <div class="container gutter-sm">
+            <div class="section-body"></div>
+        </div>
+        <!-- 이곳에 리뷰가 동적으로 불러와짐 -->
+    </main>
+
+
+    <div class="loading-indicator" id="loading">로딩 중...</div>
+</div>
+
+<div th:replace="~{template/footer :: footerFragment}"></div>
+</body>
+</html>


### PR DESCRIPTION
- OwnerReviewController로 member_seq값을 가지고 OwnerReview페이지로 이동
- OwnerReview.html 생성하고 리뷰리스트를 동적처리, member_seq값을 ajax로 보냄
- ajax를 통해 고객별 작성한 가게의 리뷰리스트 출력하는 함수 구현
- OwnerReviewApi를 통해 데이터 로드
- ReviewService에서 mapper를 통해 ReviewDTO 값 리턴
- ReviewMapper에서 점주가 가지고 있는 레스토랑들에 관한 리뷰 값 출력
- ReviewDTO에 restaurant_name값 추가
- 리뷰가 두개씩만 반복되는 문제 수정
- 정렬 최신순으로 변경

- '어디로 가시나요?', '카테고리별 리스트' 정렬 별점 순으로 변경